### PR TITLE
Add support for NAT Gateway instead of ALB, Fix some formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ module "fargate" {
 }
 ```
 
+If you want to run with a NAT Gateway instead of a load balancer, set `use_nat` to `true`.
+This will create a NAT Gateway in each public subnet instead of a load balancer.
+
 ### Using with ECR:
 
 If you are using Amazon ECR to host custom docker images, you will need to add the following IAM permissions.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "private_subnets" {
   description = "List of private subnets (on the ECS service hosting fargate)."
-  value = aws_subnet.fargate_ecs
+  value       = aws_subnet.fargate_ecs
 }
 
 output "public_subnets" {
   description = "List of public subnets (on the load balancer)."
-  value = aws_subnet.fargate_public
+  value       = aws_subnet.fargate_public
 }
 
 output "iam_role" {
   description = "IAM role for the fargate cluster. Can be used to link additional IAM permissions."
-  value = aws_iam_role.fargate_role
+  value       = aws_iam_role.fargate_role
 }
 
 output "public_security_group_id" {
   description = "Id of the public security group (containing ALB)."
-  value = aws_security_group.alb.id
+  value       = aws_security_group.alb.id
 }
 
 output "private_security_group_id" {
   description = "Id of the private security group (containing ECS Cluster)."
-  value = aws_security_group.fargate_ecs.id
+  value       = aws_security_group.fargate_ecs.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,31 +1,31 @@
 variable "region" {
-  type = string
+  type        = string
   description = "AWS region resources will be deployed in."
 }
 
 variable "app_name" {
-  type = string
+  type        = string
   description = "The name of the app in this fargate cluster."
 }
 
 variable "env_name" {
-  type = string
+  type        = string
   description = "Name of environment"
 }
 
 variable "az_count" {
-  type = string
+  type        = string
   description = "Number of Availability zones to deploy into within region"
-  default = 2
+  default     = 2
 }
 
 variable "vpc_id" {
   description = "ID of VPC to deploy the Fargate cluster into."
-  type = string
+  type        = string
 }
 
 variable "image_name" {
-  type = string
+  type        = string
   description = "Name of the docker image to apply."
 }
 
@@ -34,44 +34,50 @@ variable "environment" {
 }
 
 variable "cpu_units" {
-  type = string
+  type        = string
   description = "CPU Units to allocate to task definition."
 }
 
 variable "ram_units" {
-  type = string
+  type        = string
   description = "RAM units to allocate to task definition."
 }
 
 variable "task_group_family" {
-  type = string
+  type        = string
   description = "Name of task group family."
 }
 
 variable "cidr_bit_offset" {
-  type = string
+  type        = string
   description = "Offset for CIDR mask when applying to existing VPC."
 }
 
 variable "container_port" {
-  type = number
+  type        = number
   description = "Container port for the container"
 }
 
 variable "https_enabled" {
-  type = bool
+  type        = bool
   description = "Is Https enabled? Certifcate arn needs to be set if this is true"
-  default = false
+  default     = false
+}
+
+variable "use_nat" {
+  type        = bool
+  description = "Use NAT Gateway instead of ALB"
+  default     = false
 }
 
 variable "cert_arn" {
-  type = string
+  type        = string
   description = "ARN path to certificate resource"
-  default = ""
+  default     = ""
 }
 
 variable "create_iam_service_linked_role" {
-  type = bool
+  type        = bool
   description = "Whether to create IAM service role for ECS. If you already have one in your account this can be false"
-  default = false
+  default     = false
 }


### PR DESCRIPTION
Adds support for using a NAT Gateway for internet access instead of an Application Load Balancer.

Useful for when the container being run is a background process that does not serve content but still needs to access services via the internet.

When `use_nat` is set to `true` the NAT Gateway will be placed in the public subnets instead of an Application Load Balancer.

Also makes formatting follow terraform standards.