### PR TITLE
Remove launch type parameter because it conflicts with capacity provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,7 +227,6 @@ resource "aws_ecs_service" "fargate" {
   desired_count                      = var.desired_tasks
   deployment_maximum_percent         = var.maxiumum_healthy_task_percent
   deployment_minimum_healthy_percent = var.minimum_healthy_task_percent
-  launch_type                        = "FARGATE"
 
   capacity_provider_strategy {
     capacity_provider = var.capacity_provider


### PR DESCRIPTION
Removes `launch_type` parameter I forgot to remove in #3 