### PR TITLE
Add quick fix to stop using list function deprecated in terraform 12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -240,7 +240,7 @@ resource "aws_ecs_service" "fargate" {
   }
 
   dynamic "load_balancer" {
-    for_each = local.nat_enabled ? [] : list(1)
+    for_each = local.nat_enabled ? [] : [1]
 
     content {
       target_group_arn = aws_alb_target_group.fargate.id


### PR DESCRIPTION
This was an open I forgot about, but Terraform has removed `list` in newer version of terraform. It makes sense to just do `[1]` as a quick fix for now.

Resolves #6 